### PR TITLE
Temporal header menu cleanup

### DIFF
--- a/web/components/header/headermap.ts
+++ b/web/components/header/headermap.ts
@@ -21,18 +21,20 @@ export const HeaderMap: HeaderMap[] = [
   //   Products,
   // temporarily disabled
   //   WhyBridged,
-  {
-    label: "Pricing",
-    href: "/pricing",
-  },
+  // temporarily disabled - since the pricing policy is not firm
+  // {
+  //   label: "Pricing",
+  //   href: "/pricing",
+  // },
   {
     label: "Docs",
     href: "/docs",
   },
-  {
-    label: "Blog",
-    href: URLS.social.medium,
-  },
+  // temporarily disabled - since the blog standards is not firm
+  // {
+  //   label: "Blog",
+  //   href: URLS.social.medium,
+  // },
   {
     label: "Github",
     href: URLS.social.github,


### PR DESCRIPTION
From 
![image](https://user-images.githubusercontent.com/16307013/139386389-0d52c72a-9ecc-4f8b-9f87-d0d148b7c44a.png)

To

![image](https://user-images.githubusercontent.com/16307013/139386287-d6ebe47f-59fc-4713-ae32-c2cc79d7405f.png)

Rm
- /blog (router still lives)
- /pricing (router still lives)