### PR TITLE
code block breaks the layout.

### DIFF
--- a/web/components/docs-mdx/post-body.tsx
+++ b/web/components/docs-mdx/post-body.tsx
@@ -28,6 +28,7 @@ export default function PostBody({ content }) {
 
   return (
     <div className="max-w-2xl mx-auto">
+      {/* width: calc(100% - 310px - 40px); */}
       <Documentation>
         <div
           dangerouslySetInnerHTML={{

--- a/web/components/docs-mdx/post-body.tsx
+++ b/web/components/docs-mdx/post-body.tsx
@@ -28,7 +28,6 @@ export default function PostBody({ content }) {
 
   return (
     <div className="max-w-2xl mx-auto">
-      {/* width: calc(100% - 310px - 40px); */}
       <Documentation>
         <div
           dangerouslySetInnerHTML={{
@@ -75,6 +74,12 @@ export default function PostBody({ content }) {
     </div>
   );
 }
+
+const Wrapper = styled.div`
+  /* max-width: 42rem; */
+  /* margin-left: auto;
+  margin-right: auto; */
+`;
 
 const CustomIcon = styled(Icon)`
   svg {

--- a/web/components/docs-mdx/post-body.tsx
+++ b/web/components/docs-mdx/post-body.tsx
@@ -28,13 +28,11 @@ export default function PostBody({ content }) {
 
   return (
     <div className="max-w-2xl mx-auto">
-      <Documentation>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: docs,
-          }}
-        />
-      </Documentation>
+      <Documentation
+        dangerouslySetInnerHTML={{
+          __html: docs,
+        }}
+      ></Documentation>
       <Flex justifyContent="space-between" mt="90px">
         <Flex className="cursor" alignItems="center">
           <CustomIcon
@@ -74,12 +72,6 @@ export default function PostBody({ content }) {
     </div>
   );
 }
-
-const Wrapper = styled.div`
-  /* max-width: 42rem; */
-  /* margin-left: auto;
-  margin-right: auto; */
-`;
 
 const CustomIcon = styled(Icon)`
   svg {

--- a/web/components/docs-mdx/post-body.tsx
+++ b/web/components/docs-mdx/post-body.tsx
@@ -28,11 +28,13 @@ export default function PostBody({ content }) {
 
   return (
     <div className="max-w-2xl mx-auto">
-      <Documentation
-        dangerouslySetInnerHTML={{
-          __html: docs,
-        }}
-      />
+      <Documentation>
+        <div
+          dangerouslySetInnerHTML={{
+            __html: docs,
+          }}
+        />
+      </Documentation>
       <Flex justifyContent="space-between" mt="90px">
         <Flex className="cursor" alignItems="center">
           <CustomIcon

--- a/web/pages/docs/[...path].tsx
+++ b/web/pages/docs/[...path].tsx
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled";
 import DocsNavigation from "layout/docs-navigation";
 import ErrorPage from "next/error";
 import Head from "next/head";
@@ -21,7 +22,7 @@ export default function Post({ post, preview }) {
         <PostTitle>Loading…</PostTitle>
       ) : (
         <>
-          <article style={{ width: "calc(100% - 40px)", margin: "0px 20px" }}>
+          <Article>
             <Head>
               <title>{post.title}</title>
               {post.ogImage && (
@@ -29,7 +30,7 @@ export default function Post({ post, preview }) {
               )}
             </Head>
             <PostBody content={post.content} />
-          </article>
+          </Article>
         </>
       )}
     </Layout>
@@ -68,3 +69,14 @@ export async function getStaticPaths() {
     fallback: true,
   };
 }
+
+const Article = styled.article`
+  width: calc(100% - 40px);
+  margin: 0px 20px;
+
+  @media screen and (min-width: 768px) {
+    width: calc(100% - 320px - 40px);
+    /* TEMPORARY! */
+    /* 320px is sidebar 250px + sidebar margin 70px */
+  }
+`;


### PR DESCRIPTION
If the width of the code in the `code block` gets longer, it breaks the layout without any parent control.

It seems that it is necessary to specify the width in the `post-body`.


breakable view
 https://www.grida.co/docs/@designto-code/figma-text-autoresize
<img width="848" alt="Screen Shot 2021-11-08 at 6 06 54 PM" src="https://user-images.githubusercontent.com/40289200/140733368-6aa53981-4fef-4719-8122-6d262e19f77f.png">

unbreakable view
 https://www.grida.co/docs/@designto-code/figma-line
<img width="748" alt="Screen Shot 2021-11-08 at 8 27 24 PM" src="https://user-images.githubusercontent.com/40289200/140734151-2276f24d-8f9c-4833-b293-b597952c3dcf.png">


issue link: https://github.com/gridaco/grida.co/issues/111